### PR TITLE
Include pkg-config in build workflow packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,9 @@ jobs:
     uses: Itexoft/DevOpsKit/.github/workflows/autotools-multi-rid-build.yml@master
     with:
       project_name: samba
-      apt_packages: libgnutls28-dev libpopt-dev python3
-      brew_packages: gnutls popt python
-      msys2_packages: mingw-w64-x86_64-gnutls mingw-w64-x86_64-popt mingw-w64-x86_64-python
+      apt_packages: libgnutls28-dev libpopt-dev python3 pkg-config
+      brew_packages: gnutls popt python pkg-config
+      msys2_packages: mingw-w64-x86_64-gnutls mingw-w64-x86_64-popt mingw-w64-x86_64-python mingw-w64-x86_64-pkg-config
       pre_setup_script_linux: |
         pkg-config --version
       pre_setup_script_macos: |


### PR DESCRIPTION
## Summary
- ensure pkg-config is installed by adding it to apt, brew, and MSYS2 packages

## Testing
- `yamllint .github/workflows/build.yml` *(fails: line length and document start warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a28338ecd0832da83d08fbf45af086