### PR TITLE
fix: export PKG_CONFIG_PATH during macOS setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,8 @@ jobs:
         GP=$(brew --prefix gpgme)/lib/pkgconfig
         LA=$(brew --prefix libassuan)/lib/pkgconfig
         GE=$(brew --prefix libgpg-error)/lib/pkgconfig
-        echo "PKG_CONFIG_PATH=$GP:$LA:$GE:$PKG_CONFIG_PATH" >> $GITHUB_ENV
+        export PKG_CONFIG_PATH=$GP:$LA:$GE:$PKG_CONFIG_PATH
+        echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH" >> $GITHUB_ENV
         pip3 install gpg
       pre_setup_script_windows: |
         pkg-config --version || true


### PR DESCRIPTION
## Summary
- export PKG_CONFIG_PATH before installing gpg on macOS

## Testing
- `python3 -m py_compile python/samba/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68a2ca3b228c832d90c38df1246fd886