### PR TITLE
ci: fix platform builds and split jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@
   workflow_dispatch:
 
 jobs:
-  build:
+  build-linux:
     uses: Itexoft/DevOpsKit/.github/workflows/autotools-multi-rid-build.yml@master
     with:
       project_name: samba
@@ -27,21 +27,10 @@ jobs:
         glusterfs-common libcephfs-dev libtracker-sparql-3.0-dev
         build-essential debhelper docbook-xml docbook-xsl libkeyutils-dev
         xz-utils libnsl-dev libtirpc-dev
-      brew_packages: >
-        gnutls popt python pkg-config openldap lmdb gpgme gnupg jansson
-        libtirpc flex cups libarchive dbus glib tracker
-        autoconf automake libtool git gdb perl cpanminus gpgmepy
       pre_setup_script_linux: |
         pkg-config --version
-      pre_setup_script_macos: |
-        pkg-config --version
-        cpanm Parse::Yapp
-        GP=$(brew --prefix gpgme)/lib/pkgconfig
-        LA=$(brew --prefix libassuan)/lib/pkgconfig
-        GE=$(brew --prefix libgpg-error)/lib/pkgconfig
-        export PKG_CONFIG_PATH=$GP:$LA:$GE:$PKG_CONFIG_PATH
-        echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH" >> $GITHUB_ENV
       enable_windows: "false"
+      enable_macos: "false"
       pre_configure_script: |
         autoreconf -i || true
       configure_path: ./configure
@@ -50,6 +39,33 @@ jobs:
       checkout_submodules: "recursive"
       extra_env_linux: |
         CCACHE_DIR=/tmp/.ccache
+    secrets: inherit
+
+  build-macos:
+    uses: Itexoft/DevOpsKit/.github/workflows/autotools-multi-rid-build.yml@master
+    with:
+      project_name: samba
+      brew_packages: >
+        gnutls popt python pkg-config openldap lmdb gpgme gnupg jansson
+        libtirpc flex cups libarchive dbus glib tracker
+        autoconf automake libtool git gdb perl cpanminus swig
+      pre_setup_script_macos: |
+        pkg-config --version
+        cpanm Parse::Yapp
+        GP=$(brew --prefix gpgme)/lib/pkgconfig
+        LA=$(brew --prefix libassuan)/lib/pkgconfig
+        GE=$(brew --prefix libgpg-error)/lib/pkgconfig
+        export PKG_CONFIG_PATH=$GP:$LA:$GE:$PKG_CONFIG_PATH
+        echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH" >> $GITHUB_ENV
+        pip3 install gpg
+      enable_linux: "false"
+      enable_windows: "false"
+      pre_configure_script: |
+        autoreconf -i || true
+      configure_path: ./configure
+      build_dir: ""
+      autoreconf: "false"
+      checkout_submodules: "recursive"
       extra_env_macos: |
         CCACHE_DIR=/tmp/.ccache
     secrets: inherit
@@ -64,7 +80,7 @@ jobs:
         with:
           msystem: MINGW64
           install: >-
-            base-devel git perl cpanminus flex
+            base-devel git perl perl-App-cpanminus flex
             mingw-w64-x86_64-toolchain
             mingw-w64-x86_64-pkg-config
             mingw-w64-x86_64-gnutls


### PR DESCRIPTION
## Summary
- split Linux and macOS builds into separate jobs
- fix MSYS2 cpanminus package name
- install python gpg bindings on macOS

## Testing
- `python3 -m yamllint .github/workflows/build.yml` *(fails: line too long)*

------
https://chatgpt.com/codex/tasks/task_e_68a2dd91c26c832db47f52068e722e7e