### PR TITLE
Archive build outputs without nested directories

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,3 +102,16 @@ jobs:
           ./configure --without-acl-support --without-gettext --bundled-libraries=ALL
 
           make JOBS="$(sysctl -n hw.ncpu)"
+
+      - name: archive
+        run: |
+          mkdir -p out
+          find bin -type f -perm /111 -exec cp {} out/ \; || true
+          if [ "$(ls -A out)" ]; then
+            tar -czf samba-${{ matrix.os }}.tar.gz -C out .
+          fi
+      - uses: actions/upload-artifact@v4
+        if: ${{ hashFiles('samba-' + matrix.os + '.tar.gz') != '' }}
+        with:
+          name: samba-${{ matrix.os }}
+          path: samba-${{ matrix.os }}.tar.gz


### PR DESCRIPTION
## Summary
- archive build artifacts in workflow without extra directories

## Testing
- `yamllint .github/workflows/build.yml` *(fails: line too long)*

------
https://chatgpt.com/codex/tasks/task_e_68a3f7e56a78832dbc7e2cc4444bff0c