### PR TITLE
ci: avoid duplicate brew installs and build on Linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,13 +37,20 @@ jobs:
             docbook-xml docbook-xsl libkeyutils-dev xz-utils libnsl-dev libtirpc-dev
           pkg-config --modversion gpgme
           python3 -c "import gpg; print('gpg py ok')"
-          
+
+      - name: Linux build
+        if: runner.os == 'Linux'
+        run: |
+          ./configure --without-acl-support --without-gettext --bundled-libraries=ALL
+          make -j$(nproc)
+
       - name: macOS deps + build
         if: runner.os == 'macOS'
         run: |
           brew update
-          brew reinstall gpgme libassuan libgpg-error gettext
-          brew install gpgmepy gnupg gnutls popt python pkg-config openldap lmdb jansson libtirpc flex bison cups libarchive dbus glib autoconf automake libtool git gdb perl cpanminus swig krb5 readline libxcrypt icu4c utf8proc cmocka openssl@3 python-markdown
+          for pkg in gpgme libassuan libgpg-error gettext gpgmepy gnupg gnutls popt python pkg-config openldap lmdb jansson libtirpc flex bison cups libarchive dbus glib autoconf automake libtool git gdb perl cpanminus swig krb5 readline libxcrypt icu4c utf8proc cmocka openssl@3 python-markdown; do
+            brew list "$pkg" >/dev/null 2>&1 || brew install "$pkg"
+          done
           cpanm Parse::Yapp
 
           B=$(brew --prefix)


### PR DESCRIPTION
## Summary
- avoid reinstalling Homebrew formulas and guard installs to prevent duplicate warnings
- build Samba on Linux to generate artifacts

## Testing
- `~/.local/bin/yamllint -d '{extends: default, rules: {line-length: {max: 500}}}' .github/workflows/build.yml`

------
https://chatgpt.com/codex/tasks/task_e_68a404eb78ac832dab0a00f9c5b115b1